### PR TITLE
Allow Construction of Binary Ops and implement printing for If statements

### DIFF
--- a/src/subset/ast.rs
+++ b/src/subset/ast.rs
@@ -19,9 +19,14 @@ pub enum Unop {
 
 #[derive(Clone, Debug)]
 pub enum Binop {
+    LogOr,
+    LogAnd,
     Add,
     Mul,
+    Gt,
     Lt,
+    Geq,
+    Leq,
     Equal,
     NotEqual,
     IndexBit,

--- a/src/subset/helpers.rs
+++ b/src/subset/helpers.rs
@@ -34,8 +34,11 @@ impl Expr {
         }
     }
 
-    pub fn new_ref(name: &str) -> Expr {
-        Expr::Ref(name.to_string())
+    pub fn new_ref<S>(name: S) -> Expr
+    where
+        S: AsRef<str>,
+    {
+        Expr::Ref(name.as_ref().to_string())
     }
 
     pub fn new_signed_ref(name: &str) -> Expr {

--- a/src/subset/helpers.rs
+++ b/src/subset/helpers.rs
@@ -109,6 +109,10 @@ impl Expr {
         Expr::Terop(Terop::Mux, Rc::new(cond), Rc::new(tru), Rc::new(fal))
     }
 
+    pub fn new_not(exp: Expr) -> Expr {
+        Expr::Unop(Unop::Not, Rc::new(exp))
+    }
+
     pub fn new_slice(var: &str, hi: Expr, lo: Expr) -> Expr {
         Expr::Terop(
             Terop::Slice,

--- a/src/subset/helpers.rs
+++ b/src/subset/helpers.rs
@@ -65,12 +65,32 @@ impl Expr {
         Expr::ULit(width, Radix::Bin, value.to_string())
     }
 
+    pub fn new_logical_or(lhs: Expr, rhs: Expr) -> Expr {
+        Expr::Binop(Binop::LogOr, Rc::new(lhs), Rc::new(rhs))
+    }
+
+    pub fn new_logical_and(lhs: Expr, rhs: Expr) -> Expr {
+        Expr::Binop(Binop::LogAnd, Rc::new(lhs), Rc::new(rhs))
+    }
+
     pub fn new_add(lhs: Expr, rhs: Expr) -> Expr {
         Expr::Binop(Binop::Add, Rc::new(lhs), Rc::new(rhs))
     }
 
+    pub fn new_gt(lhs: Expr, rhs: Expr) -> Expr {
+        Expr::Binop(Binop::Gt, Rc::new(lhs), Rc::new(rhs))
+    }
+
     pub fn new_lt(lhs: Expr, rhs: Expr) -> Expr {
         Expr::Binop(Binop::Lt, Rc::new(lhs), Rc::new(rhs))
+    }
+
+    pub fn new_geq(lhs: Expr, rhs: Expr) -> Expr {
+        Expr::Binop(Binop::Geq, Rc::new(lhs), Rc::new(rhs))
+    }
+
+    pub fn new_leq(lhs: Expr, rhs: Expr) -> Expr {
+        Expr::Binop(Binop::Leq, Rc::new(lhs), Rc::new(rhs))
     }
 
     pub fn new_eq(lhs: Expr, rhs: Expr) -> Expr {

--- a/src/subset/pretty_print.rs
+++ b/src/subset/pretty_print.rs
@@ -20,8 +20,8 @@ impl PrettyPrint for Unop {
 impl PrettyPrint for Binop {
     fn to_doc(&self) -> RcDoc<()> {
         match self {
-            Binop::LogOr => RcDoc::text("|"),
-            Binop::LogAnd => RcDoc::text("&"),
+            Binop::LogOr => RcDoc::text("||"),
+            Binop::LogAnd => RcDoc::text("&&"),
             Binop::Add => RcDoc::text("+"),
             Binop::Mul => RcDoc::text("*"),
             Binop::Lt => RcDoc::text("<"),

--- a/src/subset/pretty_print.rs
+++ b/src/subset/pretty_print.rs
@@ -25,12 +25,12 @@ impl PrettyPrint for Binop {
             Binop::Add => RcDoc::text("+"),
             Binop::Mul => RcDoc::text("*"),
             Binop::Lt => RcDoc::text("<"),
+            Binop::Gt => RcDoc::text(">"),
+            Binop::Geq => RcDoc::text(">="),
+            Binop::Leq => RcDoc::text("<="),
             Binop::Equal => RcDoc::text("=="),
             Binop::NotEqual => RcDoc::text("!="),
             Binop::IndexBit => RcDoc::nil(),
-            Binop::Gt => RcDoc::text(">"),
-            Binop::Geq => RcDoc::text(">="),
-            Binop::Leq => RcDoc::text("<"),
         }
     }
 }

--- a/src/subset/pretty_print.rs
+++ b/src/subset/pretty_print.rs
@@ -20,12 +20,17 @@ impl PrettyPrint for Unop {
 impl PrettyPrint for Binop {
     fn to_doc(&self) -> RcDoc<()> {
         match self {
+            Binop::LogOr => RcDoc::text("|"),
+            Binop::LogAnd => RcDoc::text("&"),
             Binop::Add => RcDoc::text("+"),
             Binop::Mul => RcDoc::text("*"),
             Binop::Lt => RcDoc::text("<"),
             Binop::Equal => RcDoc::text("=="),
             Binop::NotEqual => RcDoc::text("!="),
             Binop::IndexBit => RcDoc::nil(),
+            Binop::Gt => RcDoc::text(">"),
+            Binop::Geq => RcDoc::text(">="),
+            Binop::Leq => RcDoc::text("<"),
         }
     }
 }

--- a/src/v17/ast.rs
+++ b/src/v17/ast.rs
@@ -41,8 +41,15 @@ pub enum Sequential {
     SeqCase(Case),
     SeqCall(Expr),
     Event(EventTy, Expr),
-    If(Expr, Vec<Sequential>, Vec<Sequential>),
+    If(SequentialIfElse),
     Assert(Expr, Option<Rc<Sequential>>),
+}
+
+#[derive(Clone, Debug)]
+pub struct SequentialIfElse {
+    pub cond: Expr,
+    pub true_branch: Vec<Sequential>,
+    pub false_branch: Vec<Sequential>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/v17/ast.rs
+++ b/src/v17/ast.rs
@@ -32,6 +32,13 @@ pub enum Decl {
     Param(Id, Ty, Expr),
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct SequentialIfElse {
+    pub cond: Option<Expr>,
+    pub body: Vec<Sequential>,
+    pub else_branch: Option<Rc<Sequential>>,
+}
+
 #[derive(Clone, Debug)]
 pub enum Sequential {
     Error(String),
@@ -43,13 +50,6 @@ pub enum Sequential {
     Event(EventTy, Expr),
     If(SequentialIfElse),
     Assert(Expr, Option<Rc<Sequential>>),
-}
-
-#[derive(Clone, Debug)]
-pub struct SequentialIfElse {
-    pub cond: Expr,
-    pub true_branch: Vec<Sequential>,
-    pub false_branch: Vec<Sequential>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/v17/ast.rs
+++ b/src/v17/ast.rs
@@ -15,6 +15,9 @@ pub type Function = subset::ast::GenericFunction<Decl, Sequential, Ty>;
 pub type Stmt = subset::ast::GenericStmt<Decl, Parallel>;
 pub type Port = subset::ast::GenericPort<Decl>;
 pub type Module = subset::ast::GenericModule<Decl, Parallel>;
+pub type Binop = subset::ast::Binop;
+pub type Unop = subset::ast::Unop;
+pub type Radix = subset::ast::Radix;
 
 #[derive(Clone, Debug)]
 pub enum Ty {

--- a/src/v17/ast.rs
+++ b/src/v17/ast.rs
@@ -15,9 +15,6 @@ pub type Function = subset::ast::GenericFunction<Decl, Sequential, Ty>;
 pub type Stmt = subset::ast::GenericStmt<Decl, Parallel>;
 pub type Port = subset::ast::GenericPort<Decl>;
 pub type Module = subset::ast::GenericModule<Decl, Parallel>;
-pub type Binop = subset::ast::Binop;
-pub type Unop = subset::ast::Unop;
-pub type Radix = subset::ast::Radix;
 
 #[derive(Clone, Debug)]
 pub enum Ty {

--- a/src/v17/display.rs
+++ b/src/v17/display.rs
@@ -32,6 +32,12 @@ impl fmt::Display for Sequential {
     }
 }
 
+impl fmt::Display for SequentialIfElse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_pretty())
+    }
+}
+
 impl fmt::Display for Parallel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_pretty())

--- a/src/v17/from.rs
+++ b/src/v17/from.rs
@@ -1,0 +1,7 @@
+use super::ast::*;
+
+impl From<SequentialIfElse> for Sequential {
+    fn from(seq: SequentialIfElse) -> Self {
+        Sequential::If(seq)
+    }
+}

--- a/src/v17/helpers.rs
+++ b/src/v17/helpers.rs
@@ -245,8 +245,11 @@ impl Decl {
         )
     }
 
-    pub fn new_logic(name: &str, width: u64) -> Decl {
-        Decl::Logic(name.to_string(), Ty::new_width(width))
+    pub fn new_logic<S>(name: S, width: u64) -> Decl
+    where
+        S: AsRef<str>,
+    {
+        Decl::Logic(name.as_ref().to_string(), Ty::new_width(width))
     }
 
     pub fn new_func(func: Function) -> Decl {
@@ -291,6 +294,10 @@ impl Module {
 
     pub fn add_output(&mut self, name: &str, width: u64) {
         self.ports.push(Port::new_output(name, width));
+    }
+
+    pub fn add_decl(&mut self, decl: Decl) {
+        self.body.push(Stmt::new_decl(decl));
     }
 
     pub fn add_function(&mut self, func: Function) {

--- a/src/v17/helpers.rs
+++ b/src/v17/helpers.rs
@@ -141,18 +141,18 @@ impl Sequential {
 impl SequentialIfElse {
     pub fn new(cond: Expr) -> Self {
         SequentialIfElse {
-            cond,
-            true_branch: vec![],
-            false_branch: vec![],
+            cond: Some(cond),
+            body: vec![],
+            else_branch: None,
         }
     }
 
-    pub fn add_true_seq(&mut self, seq: Sequential) {
-        self.true_branch.push(seq);
+    pub fn add_seq(&mut self, seq: Sequential) {
+        self.body.push(seq);
     }
 
-    pub fn add_false_seq(&mut self, seq: Sequential) {
-        self.false_branch.push(seq);
+    pub fn set_else(&mut self, seq: Sequential) {
+        self.else_branch = Some(Rc::new(seq));
     }
 }
 

--- a/src/v17/helpers.rs
+++ b/src/v17/helpers.rs
@@ -138,6 +138,24 @@ impl Sequential {
     }
 }
 
+impl SequentialIfElse {
+    pub fn new(cond: Expr) -> Self {
+        SequentialIfElse {
+            cond,
+            true_branch: vec![],
+            false_branch: vec![],
+        }
+    }
+
+    pub fn add_true_seq(&mut self, seq: Sequential) {
+        self.true_branch.push(seq);
+    }
+
+    pub fn add_false_seq(&mut self, seq: Sequential) {
+        self.false_branch.push(seq);
+    }
+}
+
 impl Default for AlwaysComb {
     fn default() -> AlwaysComb {
         AlwaysComb { body: Vec::new() }

--- a/src/v17/mod.rs
+++ b/src/v17/mod.rs
@@ -1,4 +1,5 @@
 pub mod ast;
 pub mod display;
+pub mod from;
 pub mod helpers;
 pub mod pretty_print;

--- a/src/v17/pretty_print.rs
+++ b/src/v17/pretty_print.rs
@@ -132,7 +132,7 @@ impl PrettyPrint for Function {
 
 impl PrettyPrint for Decl {
     fn to_doc(&self) -> RcDoc<()> {
-        match self {
+        let doc = match self {
             Decl::Int(name, ty) => ty
                 .to_doc()
                 .append(RcDoc::space())
@@ -158,7 +158,8 @@ impl PrettyPrint for Decl {
                 .append(RcDoc::text("="))
                 .append(RcDoc::space())
                 .append(expr.to_doc()),
-        }
+        };
+        doc.append(";")
     }
 }
 

--- a/src/v17/pretty_print.rs
+++ b/src/v17/pretty_print.rs
@@ -198,8 +198,48 @@ impl PrettyPrint for Sequential {
                     cond
                 }
             }
-            _ => unimplemented!(),
+            Sequential::If(cond, tr, fa) => {
+                let tr_doc_wrapped = if tr.len() == 1 && matches!(tr[0], Sequential::If(..)) {
+                    tr.to_doc()
+                } else {
+                    RcDoc::text("begin")
+                        .append(
+                            RcDoc::line()
+                                .append(tr.to_doc())
+                                .nest(2)
+                                .append(RcDoc::line()),
+                        )
+                        .append("end")
+                };
+                let fa_doc_wrapped = if fa.len() == 1 && matches!(fa[0], Sequential::If(..)) {
+                    fa.to_doc()
+                } else {
+                    RcDoc::text("begin")
+                        .append(
+                            RcDoc::line()
+                                .append(fa.to_doc())
+                                .nest(2)
+                                .append(RcDoc::line()),
+                        )
+                        .append("end")
+                };
+                RcDoc::text("if")
+                    .append(RcDoc::space())
+                    .append(cond.to_doc().parens())
+                    .append(RcDoc::space())
+                    .append(tr_doc_wrapped)
+                    .append(RcDoc::space())
+                    .append("else")
+                    .append(RcDoc::space())
+                    .append(fa_doc_wrapped)
+            }
         }
+    }
+}
+
+impl PrettyPrint for Vec<Sequential> {
+    fn to_doc(&self) -> RcDoc<()> {
+        RcDoc::intersperse(self.iter().map(PrettyPrint::to_doc), RcDoc::line())
     }
 }
 

--- a/src/v17/pretty_print.rs
+++ b/src/v17/pretty_print.rs
@@ -132,7 +132,7 @@ impl PrettyPrint for Function {
 
 impl PrettyPrint for Decl {
     fn to_doc(&self) -> RcDoc<()> {
-        let doc = match self {
+        match self {
             Decl::Int(name, ty) => ty
                 .to_doc()
                 .append(RcDoc::space())
@@ -158,8 +158,7 @@ impl PrettyPrint for Decl {
                 .append(RcDoc::text("="))
                 .append(RcDoc::space())
                 .append(expr.to_doc()),
-        };
-        doc.append(";")
+        }
     }
 }
 


### PR DESCRIPTION
Hello Luis!

I'm finally getting around to porting FuTIL to use vast instead of just construction strings. To get things working for us, I had to add a few more binary operations and printing for `if`. I added tests for everything as well. The printing for `if` is a little bit gnarly, so let me if you want me to make it clearer.