### PR TITLE
add type coercion for the helpers to make them easier to use

### DIFF
--- a/src/subset/from.rs
+++ b/src/subset/from.rs
@@ -5,3 +5,21 @@ impl From<ExprConcat> for Expr {
         Expr::Concat(concat)
     }
 }
+
+impl From<&str> for Expr {
+    fn from(id: &str) -> Self {
+        Expr::new_ref(id)
+    }
+}
+
+impl From<String> for Expr {
+    fn from(id: String) -> Self {
+        Expr::Ref(id)
+    }
+}
+
+impl From<i32> for Expr {
+    fn from(i: i32) -> Self {
+        Expr::new_int(i)
+    }
+}

--- a/src/subset/helpers.rs
+++ b/src/subset/helpers.rs
@@ -21,8 +21,11 @@ impl ExprConcat {
         &self.exprs
     }
 
-    pub fn add_expr(&mut self, expr: Expr) {
-        self.exprs.push(expr);
+    pub fn add_expr<E>(&mut self, expr: E)
+    where
+        E: Into<Expr>,
+    {
+        self.exprs.push(expr.into());
     }
 }
 
@@ -49,8 +52,11 @@ impl Expr {
         Expr::Signed(Rc::new(Expr::Ref(name.as_ref().to_string())))
     }
 
-    pub fn new_signed(expr: Expr) -> Expr {
-        Expr::Signed(Rc::new(expr))
+    pub fn new_signed<E>(expr: E) -> Expr
+    where
+        E: Into<Expr>,
+    {
+        Expr::Signed(Rc::new(expr.into()))
     }
 
     pub fn new_str(value: &str) -> Expr {
@@ -72,84 +78,160 @@ impl Expr {
         Expr::ULit(width, Radix::Bin, value.to_string())
     }
 
-    pub fn new_bit_or(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::BitOr, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_bit_or<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::BitOr, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_bit_and(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::BitAnd, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_bit_and<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::BitAnd, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_logical_or(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::LogOr, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_logical_or<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::LogOr, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_logical_and(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::LogAnd, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_logical_and<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::LogAnd, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_add(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::Add, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_add<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::Add, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_shift_left(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::ShiftLeft, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_shift_left<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::ShiftLeft, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_sub(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::Sub, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_sub<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::Sub, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_gt(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::Gt, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_gt<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::Gt, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_lt(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::Lt, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_lt<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::Lt, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_geq(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::Geq, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_geq<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::Geq, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_leq(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::Leq, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_leq<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::Leq, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_eq(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::Equal, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_eq<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::Equal, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_neq(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::NotEqual, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_neq<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::NotEqual, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_mul(lhs: Expr, rhs: Expr) -> Expr {
-        Expr::Binop(Binop::Mul, Rc::new(lhs), Rc::new(rhs))
+    pub fn new_mul<L, R>(lhs: L, rhs: R) -> Expr
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Expr::Binop(Binop::Mul, Rc::new(lhs.into()), Rc::new(rhs.into()))
     }
 
-    pub fn new_mux(cond: Expr, tru: Expr, fal: Expr) -> Expr {
-        Expr::Terop(Terop::Mux, Rc::new(cond), Rc::new(tru), Rc::new(fal))
-    }
-
-    pub fn new_not(exp: Expr) -> Expr {
-        Expr::Unop(Unop::Not, Rc::new(exp))
-    }
-
-    pub fn new_slice(var: &str, hi: Expr, lo: Expr) -> Expr {
+    pub fn new_mux<C, T, F>(cond: C, tru: T, fal: F) -> Expr
+    where
+        C: Into<Expr>,
+        T: Into<Expr>,
+        F: Into<Expr>,
+    {
         Expr::Terop(
-            Terop::Slice,
-            Rc::new(Expr::new_ref(var)),
-            Rc::new(hi),
-            Rc::new(lo),
+            Terop::Mux,
+            Rc::new(cond.into()),
+            Rc::new(tru.into()),
+            Rc::new(fal.into()),
         )
     }
 
-    pub fn new_index_slice(var: &str, lo: Expr, width: u32) -> Expr {
+    pub fn new_not<E>(exp: E) -> Expr
+    where
+        E: Into<Expr>,
+    {
+        Expr::Unop(Unop::Not, Rc::new(exp.into()))
+    }
+
+    pub fn new_slice<H, L>(var: &str, hi: H, lo: L) -> Expr
+    where
+        H: Into<Expr>,
+        L: Into<Expr>,
+    {
+        Expr::Terop(
+            Terop::Slice,
+            Rc::new(Expr::new_ref(var)),
+            Rc::new(hi.into()),
+            Rc::new(lo.into()),
+        )
+    }
+
+    pub fn new_index_slice<E>(var: &str, lo: E, width: u32) -> Expr
+    where
+        E: Into<Expr>,
+    {
         Expr::Terop(
             Terop::IndexSlice,
             Rc::new(Expr::new_ref(var)),
-            Rc::new(lo),
+            Rc::new(lo.into()),
             Rc::new(Expr::new_int(width as i32)),
         )
     }
@@ -162,8 +244,15 @@ impl Expr {
         )
     }
 
-    pub fn new_index_expr(var: &str, expr: Expr) -> Expr {
-        Expr::Binop(Binop::IndexBit, Rc::new(Expr::new_ref(var)), Rc::new(expr))
+    pub fn new_index_expr<E>(var: &str, expr: E) -> Expr
+    where
+        E: Into<Expr>,
+    {
+        Expr::Binop(
+            Binop::IndexBit,
+            Rc::new(Expr::new_ref(var)),
+            Rc::new(expr.into()),
+        )
     }
 
     pub fn new_int(value: i32) -> Expr {
@@ -182,8 +271,11 @@ impl Expr {
         Expr::Call(name.to_string(), params)
     }
 
-    pub fn new_repeat(times: u64, expr: Expr) -> Expr {
-        Expr::Repeat(times, Rc::new(expr))
+    pub fn new_repeat<E>(times: u64, expr: E) -> Expr
+    where
+        E: Into<Expr>,
+    {
+        Expr::Repeat(times, Rc::new(expr.into()))
     }
 }
 
@@ -258,8 +350,11 @@ impl Instance {
         self.attr = attr;
     }
 
-    pub fn add_param(&mut self, param: &str, value: Expr) {
-        self.params.insert(param.to_string(), value);
+    pub fn add_param<E>(&mut self, param: &str, value: E)
+    where
+        E: Into<Expr>,
+    {
+        self.params.insert(param.to_string(), value.into());
     }
 
     pub fn add_param_uint(&mut self, param: &str, value: u32) {
@@ -273,8 +368,11 @@ impl Instance {
         self.params.insert(param.to_string(), Expr::new_str(value));
     }
 
-    pub fn connect(&mut self, port: &str, expr: Expr) {
-        self.ports.insert(port.to_string(), expr);
+    pub fn connect<E>(&mut self, port: &str, expr: E)
+    where
+        E: Into<Expr>,
+    {
+        self.ports.insert(port.to_string(), expr.into());
     }
 
     pub fn connect_ref(&mut self, port: &str, id: &str) {

--- a/src/v05/helpers.rs
+++ b/src/v05/helpers.rs
@@ -70,9 +70,12 @@ impl Port {
 }
 
 impl SequentialIfElse {
-    pub fn new(cond: Expr) -> Self {
+    pub fn new<E>(cond: E) -> Self
+    where
+        E: Into<Expr>,
+    {
         SequentialIfElse {
-            cond: Some(cond),
+            cond: Some(cond.into()),
             body: Vec::new(),
             elsebr: None,
         }
@@ -90,27 +93,40 @@ impl SequentialIfElse {
         self.elsebr.as_deref()
     }
 
-    pub fn add_seq(&mut self, seq: Sequential) {
-        self.body.push(seq);
+    pub fn add_seq<S>(&mut self, seq: S)
+    where
+        S: Into<Sequential>,
+    {
+        self.body.push(seq.into());
     }
 
-    pub fn set_else(&mut self, seq: Sequential) {
-        self.elsebr = Some(Rc::new(seq));
+    pub fn set_else<S>(&mut self, seq: S)
+    where
+        S: Into<Sequential>,
+    {
+        self.elsebr = Some(Rc::new(seq.into()));
     }
 }
 
 impl Sequential {
     pub fn new_posedge(name: &str) -> Self {
-        let expr = Expr::new_ref(name);
-        Sequential::Event(EventTy::Posedge, expr)
+        Sequential::Event(EventTy::Posedge, name.into())
     }
 
-    pub fn new_blk_assign(lexpr: Expr, rexpr: Expr) -> Sequential {
-        Sequential::Assign(lexpr, rexpr, AssignTy::Blocking)
+    pub fn new_blk_assign<L, R>(lexpr: L, rexpr: R) -> Sequential
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Sequential::Assign(lexpr.into(), rexpr.into(), AssignTy::Blocking)
     }
 
-    pub fn new_nonblk_assign(lexpr: Expr, rexpr: Expr) -> Sequential {
-        Sequential::Assign(lexpr, rexpr, AssignTy::NonBlocking)
+    pub fn new_nonblk_assign<L, R>(lexpr: L, rexpr: R) -> Sequential
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Sequential::Assign(lexpr.into(), rexpr.into(), AssignTy::NonBlocking)
     }
 
     pub fn new_case(case: Case) -> Sequential {
@@ -139,13 +155,19 @@ impl ParallelProcess {
         &self.body
     }
 
-    pub fn add_seq(&mut self, seq: Sequential) -> &mut Self {
-        self.body.push(seq);
+    pub fn add_seq<S>(&mut self, seq: S) -> &mut Self
+    where
+        S: Into<Sequential>,
+    {
+        self.body.push(seq.into());
         self
     }
 
-    pub fn set_event(&mut self, seq: Sequential) {
-        self.event = Some(seq)
+    pub fn set_event<S>(&mut self, seq: S)
+    where
+        S: Into<Sequential>,
+    {
+        self.event = Some(seq.into())
     }
 }
 
@@ -164,8 +186,11 @@ impl Parallel {
 }
 
 impl Stmt {
-    pub fn new_parallel(par: Parallel) -> Stmt {
-        Stmt::Parallel(par)
+    pub fn new_parallel<P>(par: P) -> Stmt
+    where
+        P: Into<Parallel>,
+    {
+        Stmt::Parallel(par.into())
     }
 
     pub fn new_decl(decl: Decl) -> Stmt {
@@ -236,8 +261,11 @@ impl Module {
         self.body.push(Stmt::from(decl));
     }
 
-    pub fn add_stmt(&mut self, stmt: Stmt) {
-        self.body.push(stmt);
+    pub fn add_stmt<S>(&mut self, stmt: S)
+    where
+        S: Into<Stmt>,
+    {
+        self.body.push(stmt.into());
     }
 
     pub fn set_attr(&mut self, attr: Attribute) {
@@ -246,15 +274,21 @@ impl Module {
 }
 
 impl CaseBranch {
-    pub fn new(cond: Expr) -> CaseBranch {
+    pub fn new<E>(cond: E) -> CaseBranch
+    where
+        E: Into<Expr>,
+    {
         CaseBranch {
-            cond,
+            cond: cond.into(),
             body: Vec::new(),
         }
     }
 
-    pub fn add_seq(&mut self, seq: Sequential) -> &mut Self {
-        self.body.push(seq);
+    pub fn add_seq<S>(&mut self, seq: S) -> &mut Self
+    where
+        S: Into<Sequential>,
+    {
+        self.body.push(seq.into());
         self
     }
 
@@ -269,8 +303,11 @@ impl CaseBranch {
 }
 
 impl CaseDefault {
-    pub fn add_seq(&mut self, seq: Sequential) -> &mut Self {
-        self.body.push(seq);
+    pub fn add_seq<S>(&mut self, seq: S) -> &mut Self
+    where
+        S: Into<Sequential>,
+    {
+        self.body.push(seq.into());
         self
     }
 
@@ -286,9 +323,12 @@ impl Default for CaseDefault {
 }
 
 impl Case {
-    pub fn new(cond: Expr) -> Case {
+    pub fn new<E>(cond: E) -> Case
+    where
+        E: Into<Expr>,
+    {
         Case {
-            cond,
+            cond: cond.into(),
             branches: Vec::new(),
             default: None,
         }

--- a/src/v17/helpers.rs
+++ b/src/v17/helpers.rs
@@ -39,15 +39,21 @@ impl Port {
 }
 
 impl CaseBranch {
-    pub fn new(cond: Expr) -> CaseBranch {
+    pub fn new<E>(cond: E) -> CaseBranch
+    where
+        E: Into<Expr>,
+    {
         CaseBranch {
-            cond,
+            cond: cond.into(),
             body: Vec::new(),
         }
     }
 
-    pub fn add_seq(&mut self, seq: Sequential) -> &mut Self {
-        self.body.push(seq);
+    pub fn add_seq<S>(&mut self, seq: S) -> &mut Self
+    where
+        S: Into<Sequential>,
+    {
+        self.body.push(seq.into());
         self
     }
 
@@ -62,8 +68,11 @@ impl CaseBranch {
 }
 
 impl CaseDefault {
-    pub fn add_seq(&mut self, seq: Sequential) -> &mut Self {
-        self.body.push(seq);
+    pub fn add_seq<S>(&mut self, seq: S) -> &mut Self
+    where
+        S: Into<Sequential>,
+    {
+        self.body.push(seq.into());
         self
     }
 
@@ -79,9 +88,12 @@ impl Default for CaseDefault {
 }
 
 impl Case {
-    pub fn new(cond: Expr) -> Case {
+    pub fn new<E>(cond: E) -> Case
+    where
+        E: Into<Expr>,
+    {
         Case {
-            cond,
+            cond: cond.into(),
             branches: Vec::new(),
             default: None,
         }
@@ -110,8 +122,11 @@ impl Case {
 }
 
 impl Sequential {
-    pub fn new_seqexpr(expr: Expr) -> Sequential {
-        Sequential::SeqExpr(expr)
+    pub fn new_seqexpr<E>(expr: E) -> Sequential
+    where
+        E: Into<Expr>,
+    {
+        Sequential::SeqExpr(expr.into())
     }
 
     pub fn new_error(msg: &str) -> Sequential {
@@ -122,51 +137,81 @@ impl Sequential {
         Sequential::Display(msg.to_string())
     }
 
-    pub fn new_return(expr: Expr) -> Sequential {
-        Sequential::Return(expr)
+    pub fn new_return<E>(expr: E) -> Sequential
+    where
+        E: Into<Expr>,
+    {
+        Sequential::Return(expr.into())
     }
 
-    pub fn new_assert(expr: Expr) -> Sequential {
-        Sequential::Assert(expr, None)
+    pub fn new_assert<E>(expr: E) -> Sequential
+    where
+        E: Into<Expr>,
+    {
+        Sequential::Assert(expr.into(), None)
     }
 
-    pub fn new_assert_with_else(expr: Expr, seq: Sequential) -> Sequential {
-        Sequential::Assert(expr, Some(Rc::new(seq)))
+    pub fn new_assert_with_else<E, S>(expr: E, seq: S) -> Sequential
+    where
+        E: Into<Expr>,
+        S: Into<Sequential>,
+    {
+        Sequential::Assert(expr.into(), Some(Rc::new(seq.into())))
     }
 
-    pub fn new_blk_assign(lexpr: Expr, rexpr: Expr) -> Sequential {
-        Sequential::SeqAssign(lexpr, rexpr, AssignTy::Blocking)
+    pub fn new_blk_assign<L, R>(lexpr: L, rexpr: R) -> Sequential
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Sequential::SeqAssign(lexpr.into(), rexpr.into(), AssignTy::Blocking)
     }
 
-    pub fn new_nonblk_assign(lexpr: Expr, rexpr: Expr) -> Sequential {
-        Sequential::SeqAssign(lexpr, rexpr, AssignTy::NonBlocking)
+    pub fn new_nonblk_assign<L, R>(lexpr: L, rexpr: R) -> Sequential
+    where
+        L: Into<Expr>,
+        R: Into<Expr>,
+    {
+        Sequential::SeqAssign(lexpr.into(), rexpr.into(), AssignTy::NonBlocking)
     }
 
     pub fn new_case(case: Case) -> Sequential {
         Sequential::SeqCase(case)
     }
 
-    pub fn new_call(call: Expr) -> Sequential {
-        Sequential::Call(call)
+    pub fn new_call<E>(call: E) -> Sequential
+    where
+        E: Into<Expr>,
+    {
+        Sequential::Call(call.into())
     }
 }
 
 impl SequentialIfElse {
-    pub fn new(cond: Expr) -> Self {
+    pub fn new<E>(cond: E) -> Self
+    where
+        E: Into<Expr>,
+    {
         SequentialIfElse {
-            cond: Some(cond),
+            cond: Some(cond.into()),
             body: vec![],
             else_branch: None,
         }
     }
 
-    pub fn add_seq(&mut self, seq: Sequential) -> &mut Self {
-        self.body.push(seq);
+    pub fn add_seq<S>(&mut self, seq: S) -> &mut Self
+    where
+        S: Into<Sequential>,
+    {
+        self.body.push(seq.into());
         self
     }
 
-    pub fn set_else(&mut self, seq: Sequential) {
-        self.else_branch = Some(Rc::new(seq));
+    pub fn set_else<S>(&mut self, seq: S)
+    where
+        S: Into<Sequential>,
+    {
+        self.else_branch = Some(Rc::new(seq.into()));
     }
 }
 
@@ -215,8 +260,11 @@ impl ParallelProcess {
         self.event.as_ref()
     }
 
-    pub fn add_seq(&mut self, seq: Sequential) -> &mut Self {
-        self.body.push(seq);
+    pub fn add_seq<S>(&mut self, seq: S) -> &mut Self
+    where
+        S: Into<Sequential>,
+    {
+        self.body.push(seq.into());
         self
     }
 
@@ -225,8 +273,11 @@ impl ParallelProcess {
         self
     }
 
-    pub fn set_event(&mut self, seq: Sequential) {
-        self.event = Some(seq)
+    pub fn set_event<S>(&mut self, seq: S)
+    where
+        S: Into<Sequential>,
+    {
+        self.event = Some(seq.into())
     }
 }
 
@@ -241,8 +292,11 @@ impl Parallel {
 }
 
 impl Stmt {
-    pub fn new_parallel(par: Parallel) -> Stmt {
-        Stmt::Parallel(par)
+    pub fn new_parallel<P>(par: P) -> Stmt
+    where
+        P: Into<Parallel>,
+    {
+        Stmt::Parallel(par.into())
     }
 
     pub fn new_decl(decl: Decl) -> Stmt {
@@ -302,8 +356,11 @@ impl Function {
         self
     }
 
-    pub fn add_stmt(&mut self, stmt: Sequential) -> &mut Self {
-        self.body.push(stmt);
+    pub fn add_stmt<S>(&mut self, stmt: S) -> &mut Self
+    where
+        S: Into<Sequential>,
+    {
+        self.body.push(stmt.into());
         self
     }
 

--- a/tests/v05.rs
+++ b/tests/v05.rs
@@ -217,7 +217,7 @@ fn test_sequential_if_else() {
     let mut i1 = SequentialIfElse::default();
     i0.add_seq(s0);
     i1.add_seq(s1);
-    i0.set_else(i1.into());
+    i0.set_else(i1);
     let exp = r#"if(reset) begin
     y <= 0;
 end else begin
@@ -240,7 +240,7 @@ fn test_sequential_if_else_if() {
     let mut i1 = SequentialIfElse::new(c1);
     i0.add_seq(s0);
     i1.add_seq(s1);
-    i0.set_else(i1.into());
+    i0.set_else(i1);
     let exp = r#"if(reset) begin
     y <= 0;
 end else if(en) begin

--- a/tests/v17.rs
+++ b/tests/v17.rs
@@ -415,7 +415,7 @@ fn test_seq_if_else() {
     let mut else_s = SequentialIfElse::default();
     i0.add_seq(s0);
     else_s.add_seq(s1);
-    i0.set_else(else_s.into());
+    i0.set_else(else_s);
     let exp = r#"if(reset) begin
     y <= 0;
 end else begin
@@ -438,7 +438,7 @@ fn test_seq_if_else_if() {
     let mut fbr = SequentialIfElse::new(c1);
     tbr.add_seq(s0);
     fbr.add_seq(s1);
-    tbr.set_else(fbr.into());
+    tbr.set_else(fbr);
     let exp = r#"if(reset) begin
     y <= 0;
 end else if(en) begin


### PR DESCRIPTION
Changes the helper constructors to take in `Into<...>` types wherever possible to make using the library less verbose.