### PR TITLE
Re-exported private enums

### DIFF
--- a/src/subset/helpers.rs
+++ b/src/subset/helpers.rs
@@ -211,6 +211,13 @@ impl Expr {
         Expr::Unop(Unop::Not, Rc::new(exp.into()))
     }
 
+    pub fn new_logical_not<E>(exp: E) -> Expr
+    where
+        E: Into<Expr>,
+    {
+        Expr::Unop(Unop::LogNot, Rc::new(exp.into()))
+    }
+
     pub fn new_slice<H, L>(var: &str, hi: H, lo: L) -> Expr
     where
         H: Into<Expr>,

--- a/src/v17/ast.rs
+++ b/src/v17/ast.rs
@@ -16,6 +16,9 @@ pub type Stmt = subset::ast::GenericStmt<Decl, Parallel>;
 pub type Port = subset::ast::GenericPort<Decl>;
 pub type Module = subset::ast::GenericModule<Decl, Parallel>;
 pub type ExprConcat = subset::ast::ExprConcat;
+pub type Unop = subset::ast::Unop;
+pub type Binop = subset::ast::Binop;
+pub type Terop = subset::ast::Terop;
 
 #[derive(Clone, Debug)]
 pub enum Ty {


### PR DESCRIPTION
I don't see an obvious way to access many of the operator enums. They all appear to be private.

This PR re-exports them under `v17` and adds a helper method for logical not. 